### PR TITLE
Fix Markdown syntax to RDoc syntax in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,10 +50,8 @@ TBD
 
 == Contributing
 
-In the spirit of [free software][free-sw], **everyone** is encouraged to help
+In the spirit of {free software}[http://www.fsf.org/licensing/essays/free-sw.html], **everyone** is encouraged to help
 improve this project.
-
-[free-sw]: http://www.fsf.org/licensing/essays/free-sw.html
 
 Here are some ways *you* can contribute:
 


### PR DESCRIPTION
Fix Markdown style link syntax to RDoc syntax.

This also simplifies things little bit as link was only used in one place, there really were not that good reason to do things the previous way.

More details:
http://rdoc.rubyforge.org/RDoc/Markup.html#label-Links
